### PR TITLE
STCH-790: added the possibility to specify the idle timeout 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.vonhof</groupId>
     <artifactId>webi</artifactId>
-    <version>1.6.8</version>
+    <version>1.6.9</version>
     <packaging>jar</packaging>
 
     <name>webi</name>

--- a/src/main/java/com/vonhof/webi/Webi.java
+++ b/src/main/java/com/vonhof/webi/Webi.java
@@ -101,7 +101,11 @@ public final class Webi {
     private RequestLogHandler requestLogHandler = new RequestLogHandler();
 
     public Webi(int port, int maxThreads, int acceptQueueSize, int maxConcurrentRequests) {
-        this(null, port, maxThreads, acceptQueueSize, maxConcurrentRequests);
+        this(null, port, maxThreads, acceptQueueSize, maxConcurrentRequests,30000);
+    }
+
+    public Webi(int port, int maxThreads, int acceptQueueSize, int maxConcurrentRequests, int idleTimeout) {
+        this(null, port, maxThreads, acceptQueueSize, maxConcurrentRequests,idleTimeout);
     }
 
     /**
@@ -109,7 +113,7 @@ public final class Webi {
      *
      * @param port
      */
-    public Webi(MetricRegistry registry, int port, int maxThreads, int acceptQueueSize, int maxConcurrentRequests) {
+    public Webi(MetricRegistry registry, int port, int maxThreads, int acceptQueueSize, int maxConcurrentRequests, int idleTimeout) {
         this.maxRequests = maxConcurrentRequests;
         this.registry = registry;
 
@@ -127,6 +131,7 @@ public final class Webi {
         connector.setAcceptQueueSize(acceptQueueSize);
         connector.setPort(port);
         connector.setReuseAddress(true);
+        connector.setIdleTimeout(idleTimeout);
 
         if (registry != null) {
             Collection<ConnectionFactory> connectionFactories = new ArrayList<>();


### PR DESCRIPTION
To prevent the error below we need to make the idle timeout property configurable to prevent the error below:

```
{"error":true,"msg":"java.io.IOException: java.util.concurrent.TimeoutException: Idle timeout expired: 30000/30000 ms trace":["org.eclipse.jetty.util.SharedBlockingCallback$Blocker.block(SharedBlockingCallback.java:212) org.eclipse.jetty.server.HttpOutput.write(HttpOutput.java:125) org.eclipse.jetty.server.HttpOutput.write(HttpOutput.java:339) [org.apache.commons.io](http://org.apache.commons.io/).IOUtils.copyLarge(IOUtils.java:1793) [org.apache.commons.io](http://org.apache.commons.io/).IOUtils.copyLarge(IOUtils.java:1769) io.dexi.api.proxy.RESTProxyHandler.streamOutput(RESTProxyHandler.java:216) io.dexi.api.proxy.RESTProxyHandler.forwardBodyLessRequest(RESTProxyHandler.java:161) io.dexi.api.proxy.RESTProxyHandler.forwardRequestToHost(RESTProxyHandler.java:151) io.dexi.api.proxy.RESTProxyHandler.forwardRequest(RESTProxyHandler.java:99) io.dexi.api.proxy.RESTProxyHandler.handle(RESTProxyHandler.java:76) com.vonhof.webi.Webi$Handler.doHandle(Webi.java:467) com.vonhof.webi.Webi$Handler.access$300(Webi.java:340) com.vonhof.webi.Webi$Handler$1.handle(Webi.java:357) com.vonhof.webi.Webi$Handler.throttleRequest(Webi.java:409) com.vonhof.webi.Webi$Handler.handle(Webi.java:354) org.eclipse.jetty.servlets.gzip.GzipHandler.handle(GzipHandler.java:296) org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:92) org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) org.eclipse.jetty.server.Server.handle(Server.java:485) org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:290) org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:248) [org.eclipse.jetty.io](http://org.eclipse.jetty.io/).AbstractConnection$2.run(AbstractConnection.java:540) org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:606) org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:535) java.lang.Thread.run(Thread.java:748)"],"code":500}
```